### PR TITLE
Override public_iface to host-only (enp0s8)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,6 +106,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "kube-control" => [$kube_control],
           "kube-cluster:children" => ["kube-masters", "kube-workers"],
         }
+        ansible.extra_vars        = {
+          "public_iface" => "enp0s8"
+        }
         # Additional Ansible tools for debugging:
         #ansible.inventory_path = $ansible_inventory
         #ansible.verbose        = "-vvvv"


### PR DESCRIPTION
This is related to att-comdev/halcyon-kubernetes#10, which updates support for Romana.

The halcyon-kubernetes submodule would still need updating to point at the newer changes.