### PR TITLE
Libvirt provider support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,7 +107,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "kube-cluster:children" => ["kube-masters", "kube-workers"],
         }
         ansible.extra_vars        = {
-          "public_iface" => "enp0s8"
+          "public_iface" => $public_interface
         }
         # Additional Ansible tools for debugging:
         #ansible.inventory_path = $ansible_inventory

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,9 +106,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "kube-control" => [$kube_control],
           "kube-cluster:children" => ["kube-masters", "kube-workers"],
         }
-        ansible.extra_vars        = {
-          "public_iface" => $public_interface
-        }
         # Additional Ansible tools for debugging:
         #ansible.inventory_path = $ansible_inventory
         #ansible.verbose        = "-vvvv"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,8 @@ end
 
 # Install any Required Plugins
 missing_plugins_installed = false
-required_plugins = %w(vagrant-env vagrant-git vagrant-openstack-provider)
+required_plugins = %w(vagrant-env vagrant-git vagrant-openstack-provider
+                      vagrant-libvirt)
 
 required_plugins.each do |plugin|
   if !Vagrant.has_plugin? plugin
@@ -73,6 +74,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.name = "kube#{kb}"
         vb.customize ["modifyvm", :id, "--memory", $kube_memory]
         vb.customize ["modifyvm", :id, "--cpus", $kube_vcpus]
+      end
+      # Libvirt provider (Optional --provider=libvirt):
+      kube.vm.provider "libvirt" do |lv|
+        lv.driver = "kvm"
+        lv.memory = $kube_memory
+        lv.cpus = $kube_vcpus
       end
       # Openstack Provider (Optional --provider=openstack):
       kube.vm.provider "openstack" do |os|

--- a/config.rb
+++ b/config.rb
@@ -6,6 +6,7 @@ $kube_count        = 3
 $git_commit        = "6a7308d"
 $subnet            = "192.168.236"
 $forwarded_ports   = {}
+$public_interface  = "eth1"
 
 # Ansible Declarations:
 #$number_etcd       = "kube[1:2]"

--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,7 @@ $kube_count        = 3
 $git_commit        = "6a7308d"
 $subnet            = "192.168.236"
 $forwarded_ports   = {}
-$public_interface  = "eth1"
+$public_interface  = "enp0s8"
 
 # Ansible Declarations:
 #$number_etcd       = "kube[1:2]"

--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,6 @@ $kube_count        = 3
 $git_commit        = "6a7308d"
 $subnet            = "192.168.236"
 $forwarded_ports   = {}
-$public_interface  = "enp0s8"
 
 # Ansible Declarations:
 #$number_etcd       = "kube[1:2]"


### PR DESCRIPTION
Added the ability for libvirt to be used as a provider for vagrant.  Also removed a hard coded, ubuntu specific interface ansible override