### PR TITLE
Proxy config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ end
 
 # Install any Required Plugins
 missing_plugins_installed = false
-required_plugins = %w(vagrant-env vagrant-git vagrant-openstack-provider)
+required_plugins = %w(vagrant-env vagrant-git vagrant-openstack-provider vagrant-proxyconf)
 
 required_plugins.each do |plugin|
   if !Vagrant.has_plugin? plugin
@@ -61,6 +61,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # NETWORK-SETTINGS: eth1 configured in using the $subnet variable:
       kube.vm.network "private_network", ip: "172.16.35.1#{kb}", auto_config: true
 #      kube.vm.network "public_network", ip: "#{$subnet}.#{kb}"
+      if $enable_proxy
+        config.proxy.http     = $proxy_http
+        config.proxy.https    = $proxy_https
+        config.proxy.no_proxy = "localhost,127.0.0.1"
+      end
 
       if $expose_docker_tcp
         kube.vm.network "forwarded_port", guest: 2375, host: ($expose_docker_tcp + i - 1), auto_correct: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,10 +61,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # NETWORK-SETTINGS: eth1 configured in using the $subnet variable:
       kube.vm.network "private_network", ip: "172.16.35.1#{kb}", auto_config: true
 #      kube.vm.network "public_network", ip: "#{$subnet}.#{kb}"
-      if $enable_proxy
+
+#Proxy Configuration from config.rb. Also configures the apt proxy.
+      if $proxy_enable
         config.proxy.http     = $proxy_http
         config.proxy.https    = $proxy_https
-        config.proxy.no_proxy = "localhost,127.0.0.1"
+        config.proxy.no_proxy = $proxy_no
       end
 
       if $expose_docker_tcp

--- a/config.rb
+++ b/config.rb
@@ -38,3 +38,9 @@ $os_floatnet       = "public"
 $os_fixednet       = ['vagrant-net']
 $os_keypair        = "your_ssh_keypair"
 $os_secgroups      = ["default"]
+
+#Proxy Configuration - only use if deploying behind a proxy
+$proxy_enable      = true
+$proxy_http        = "http://proxy:8080"
+$proxy_https       = "https://proxy:8080"
+$proxy_no          = "localhost,127.0.0.1"

--- a/config.rb
+++ b/config.rb
@@ -40,7 +40,7 @@ $os_keypair        = "your_ssh_keypair"
 $os_secgroups      = ["default"]
 
 #Proxy Configuration - only use if deploying behind a proxy
-$proxy_enable      = true
+$proxy_enable      = false
 $proxy_http        = "http://proxy:8080"
 $proxy_https       = "https://proxy:8080"
 $proxy_no          = "localhost,127.0.0.1"


### PR DESCRIPTION
Configuration for setting the proxy for APT, HTTP, HTTPS, and NO_PROXY. Only used when the proxy_enable variable is set to "true" in the config.rb