### PR TITLE
Fix proxy

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,10 +61,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # NETWORK-SETTINGS: eth1 configured in using the $subnet variable:
       kube.vm.network "private_network", ip: "172.16.35.1#{kb}", auto_config: true
 #      kube.vm.network "public_network", ip: "#{$subnet}.#{kb}"
-      if $enable_proxy
+      if $proxy_enable
         config.proxy.http     = $proxy_http
         config.proxy.https    = $proxy_https
-        config.proxy.no_proxy = "localhost,127.0.0.1"
+        config.proxy.no_proxy = $proxy_no
       end
 
       if $expose_docker_tcp
@@ -118,7 +118,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
           "kube-cluster:children" => ["kube-masters", "kube-workers"],
         }
         ansible.extra_vars        = {
-          "public_iface" => $public_iface
+          "public_iface" => $public_iface,
+          "public_iface" => $public_iface,
+          "proxy_enable" => $proxy_enable,
+          "proxy_http" => $proxy_http,
+          "proxy_https" => $proxy_https,
+          "proxy_no" => $proxy_no
         }
         # Additional Ansible tools for debugging:
         #ansible.inventory_path = $ansible_inventory

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,7 +119,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         }
         ansible.extra_vars        = {
           "public_iface" => $public_iface,
-          "public_iface" => $public_iface,
           "proxy_enable" => $proxy_enable,
           "proxy_http" => $proxy_http,
           "proxy_https" => $proxy_https,


### PR DESCRIPTION
Several fixes to better support running behind a proxy

- Fix mistyped variable name when checking proxy_enable
- Don't override the config file's settings for proxy_no variable
- Pass proxy values into ansible.  These values are required for a forthcoming change to halcyon-kubernetes in order to create a docker proxy config file