### PR TITLE
Feature: add user-defined configuration options for machine disk size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Vagrant deployment of [halcyon-kubernetes](https://github.com/att-comdev/halcy
       * vagrant-env
       * vagrant-git
       * vagrant-openstack-provider
+      * vagrant-persistent-storage
 
 Please see /docs/README.md for more information about SDN providers, plugins, and other useful information. Pull requests are welcome!
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ if $kube_memory < 512
 end
 
 if $kube_disk < 10
-  puts "WARNING: Your machine should have at least 10 GB of memory"
+  puts "WARNING: Your machine disk size should be at least 10 GB"
 end
 
 # Install any Required Plugins

--- a/config.rb
+++ b/config.rb
@@ -1,12 +1,20 @@
 # Kubernetes Details: Instances
 $kube_version      = "ubuntu/xenial64"
 $kube_memory       = 1024
+$kube_disk         = 15
 $kube_vcpus        = 1
 $kube_count        = 3
 $git_commit        = "6a7308d"
 $subnet            = "192.168.236"
 $public_iface      = "enp0s8"
 $forwarded_ports   = {}
+
+# Virtualbox instance additional disk properties:
+$disk_enabled      = true
+$disk_location     = "~/VirtualBox VMs/"
+$disk_image_file   = "vmdk"
+#$disk_mountname    = "xfs"
+#$disk_mountpoint   = "/mnt/xfs"
 
 # Ansible Declarations:
 #$number_etcd       = "kube[1:2]"


### PR DESCRIPTION
The user will have the ability to enter a disk size and modify the disk properties (for virtualbox users), in the config file. The minimum size must be 10GB and should be in GB. 
Virtualbox: An additional disk will be attached, in case the disk size requested is more than 10GB and the plugin vagrant-persistent-storage is required.

Closing-issue: #27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/34)
<!-- Reviewable:end -->
