### PR TITLE
Update default k8s version in setup script

### DIFF
--- a/setup-halcyon.sh
+++ b/setup-halcyon.sh
@@ -8,7 +8,7 @@ set -e
 : ${VAGRANT_VARS:="./config.rb"}
 : ${BOOTSTRAP_OS:="ubuntu"}
 : ${KUBERNETES_CONFIG:="default"}
-: ${KUBERNETES_VERSION:="v1.5.0-beta.1"}
+: ${KUBERNETES_VERSION:="v1.5.1"}
 
 usage(){
 cat <<'EOT'


### PR DESCRIPTION
This commit updates the default version of k8s used in the setup script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/41)
<!-- Reviewable:end -->
