### PR TITLE
README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ If you are deploying project on a Ubuntu 16.04+ host, you may need to install th
 
 `sudo apt-get install ruby-dev zlib1g-dev libgmp-dev libxml2-dev libssl-dev openssl libffi-dev`
 
+NOTE: On Ubuntu 16.10, you may have to install libvirt-dev package to ensure the vagrant-libvirt plugin installs properly:
+
+`sudo apt-get install libvirt-dev`
+
 
 # TODO
 


### PR DESCRIPTION
I ran into this bug trying to get halcyon environment up on my local 16.10 machine. I found the solution at this bug report:  https://github.com/vagrant-libvirt/vagrant-libvirt/issues/229

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/46)
<!-- Reviewable:end -->
