### PR TITLE
Fixing Config.rb to support 10GB volumes

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,7 @@
 # Kubernetes Details: Instances
 $kube_version      = "ubuntu/xenial64"
 $kube_memory       = 1024
-$kube_disk         = 15
+$kube_disk         = 10
 $kube_vcpus        = 1
 $kube_count        = 3
 $git_commit        = "6a7308d"


### PR DESCRIPTION
Fixing the config RB to support 10GB volumes instead of 15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/53)
<!-- Reviewable:end -->
