### PR TITLE
Updated README with halcyon-kubernetes venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Please see /docs/README.md for more information about SDN providers, plugins, an
 To use this project, simply use vagrant to bring up your environment:
 
 ```
-v1k0d3n@machine:~ $ git clone https://github.com/att-comdev/halcyon-vagrant-kubernetes.git
-v1k0d3n@machine:~ $ cd halcyon-vagrant-kubernetes
-v1k0d3n@machine:~ $ git submodule init
-v1k0d3n@machine:~ $ git submodule update
-v1k0d3n@machine:~ $ vagrant up
+$ git clone https://github.com/att-comdev/halcyon-vagrant-kubernetes.git
+$ cd halcyon-vagrant-kubernetes
+$ git submodule init
+$ git submodule update
+$ (cd halcyon-kubernetes; make clean; make; source venv/bin/activate)
+$ vagrant up
 ```
 
 ### Configuration Helper

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ git clone https://github.com/att-comdev/halcyon-vagrant-kubernetes.git
 $ cd halcyon-vagrant-kubernetes
 $ git submodule init
 $ git submodule update
-$ (cd halcyon-kubernetes; make clean; make; source venv/bin/activate)
+$ cd halcyon-kubernetes; make; source venv/bin/activate; cd -
 $ vagrant up
 ```
 


### PR DESCRIPTION
Added the steps necessary to build and enable the virtualenv
provided by halcyon-kubernetes.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/54)
<!-- Reviewable:end -->
