### PR TITLE
Minor portability updates to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A Vagrant deployment of [halcyon-kubernetes](https://github.com/att-comdev/halcy
       * vagrant-git
       * vagrant-openstack-provider
       * vagrant-persistent-storage
+  * GNU sed (MacOS ships with BSD sed)
+    - [Homebrew](http://brew.sh)
+      * `brew install gnu-sed`
+
 
 Please see /docs/README.md for more information about SDN providers, plugins, and other useful information. Pull requests are welcome!
 

--- a/get-k8s-creds.sh
+++ b/get-k8s-creds.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/usr/bin/env bash
 set -e
 # Setting up kubectl creds
 mkdir -p ${HOME}/.kube

--- a/setup-halcyon.sh
+++ b/setup-halcyon.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 set -e
 # This script simply sets up the basic defaults for a number of development
 # senarios, it is written not to be elegant, but to be portable across a wide
@@ -9,6 +9,18 @@ set -e
 : ${BOOTSTRAP_OS:="ubuntu"}
 : ${KUBERNETES_CONFIG:="default"}
 : ${KUBERNETES_VERSION:="v1.5.1"}
+
+set +e
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SED=`which gsed`
+    if [[ -z "$SED" ]]; then
+        echo "No suitable sed installed, please install gsed"
+        exit 1
+    fi
+else
+    SED=`which sed`
+fi
+set -e
 
 usage(){
 cat <<'EOT'
@@ -22,8 +34,6 @@ exit 0;
 
 # exit if there are no arguments
 [ $# -eq 0 ] && usage
-
-set -- `getopt -n$0 -u -a --longoptions "help guest-os: k8s-config: k8s-version:" "hg:c:v:" "$@"`
 
 # $# is the number of arguments
 while [ $# -gt 0 ]
@@ -49,14 +59,14 @@ set_yml_value () {
   VARIABLE=$1
   VALUE=$2
   FILE=$3
-  sed -i "/^${VARIABLE}/c\\${VARIABLE}: ${VALUE}" ${FILE}
+  $SED -i "/^${VARIABLE}/c\\${VARIABLE}: ${VALUE}" ${FILE}
 }
 
 set_rb_value () {
   VARIABLE=$1
   VALUE=$2
   FILE=$3
-  sed -i "/^\$${VARIABLE}/c\\\$${VARIABLE} = ${VALUE}" ${FILE}
+  $SED -i "/^\$${VARIABLE}/c\\\$${VARIABLE} = ${VALUE}" ${FILE}
 }
 
 set_kolla_options () {


### PR DESCRIPTION
OS X is a popular developer platform, but sadly ships with BSD
versions of many popular utils. In this script, getopt is not needed
and is widely cited as bad form to use. `sed` proved to be a more
challenging fix, as the BSD sed requires a newline after a command.
This is easy to implement in an interactive shell, but proved to
cumbersome inside a script. Instead, I chose to detect the OS, probe
for the existence of gsed, and fail if it's not installed.

Lastly, the shell interpretter was malformed as a comment, and
modern scripts are usually written with the interpreter not hardcoded.

Fixes #52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/att-comdev/halcyon-vagrant-kubernetes/55)
<!-- Reviewable:end -->
