### PR TITLE
adding OWNERS file for CI/gating

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - v1k0d3n
+  - aric49
+  - intlabs
+  - alanmeadows
+  - wilkers-steve
+  - larryrensing
+approvers:
+  - v1k0d3n
+  - aric49
+  - intlabs
+  - alanmeadows


### PR DESCRIPTION
This OWNERS file puts the repo more closely in line with our other repository [openstack-helm](https://github.com/att-comdev/openstack-helm), follows methods recommended by CNCF, and also follows our pattern for CI (as we do in openstack-helm). This will be added to both of the Halcyon repos.